### PR TITLE
Introduce abstraction over HTML and XML parsers for parser network li…

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -63,7 +63,7 @@ use dom::nodeiterator::NodeIterator;
 use dom::nodelist::NodeList;
 use dom::processinginstruction::ProcessingInstruction;
 use dom::range::Range;
-use dom::servohtmlparser::ServoHTMLParser;
+use dom::servohtmlparser::{ParserRoot, ParserRef, MutNullableParserField};
 use dom::text::Text;
 use dom::touch::Touch;
 use dom::touchevent::TouchEvent;
@@ -181,7 +181,7 @@ pub struct Document {
     /// Tracks all outstanding loads related to this document.
     loader: DOMRefCell<DocumentLoader>,
     /// The current active HTML parser, to allow resuming after interruptions.
-    current_parser: MutNullableHeap<JS<ServoHTMLParser>>,
+    current_parser: MutNullableParserField,
     /// When we should kick off a reflow. This happens during parsing.
     reflow_timeout: Cell<Option<u64>>,
     /// The cached first `base` element with an `href` attribute.
@@ -1194,9 +1194,9 @@ impl Document {
 
         // A finished resource load can potentially unblock parsing. In that case, resume the
         // parser so its loop can find out.
-        if let Some(parser) = self.current_parser.get() {
-            if parser.is_suspended() {
-                parser.resume();
+        if let Some(parser) = self.get_current_parser() {
+            if parser.r().is_suspended() {
+                parser.r().resume();
             }
         } else if self.reflow_timeout.get().is_none() {
             // If we don't have a parser, and the reflow timer has been reset, explicitly
@@ -1317,11 +1317,11 @@ impl Document {
 
     }
 
-    pub fn set_current_parser(&self, script: Option<&ServoHTMLParser>) {
+    pub fn set_current_parser(&self, script: Option<ParserRef>) {
         self.current_parser.set(script);
     }
 
-    pub fn get_current_parser(&self) -> Option<Root<ServoHTMLParser>> {
+    pub fn get_current_parser(&self) -> Option<ParserRoot> {
         self.current_parser.get()
     }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -348,7 +348,7 @@ impl HTMLScriptElement {
         // TODO: make this suspension happen automatically.
         if was_parser_inserted {
             if let Some(parser) = doc.get_current_parser() {
-                parser.suspend();
+                parser.r().suspend();
             }
         }
         return NextParserState::Suspend;

--- a/components/script/dom/servoxmlparser.rs
+++ b/components/script/dom/servoxmlparser.rs
@@ -2,15 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use dom::bindings::cell::DOMRefCell;
 use dom::bindings::js::{JS, Root};
 use dom::bindings::reflector::Reflector;
 use dom::bindings::trace::JSTraceable;
 use dom::document::Document;
 use dom::node::Node;
+use dom::servohtmlparser::ParserRef;
 use dom::text::Text;
+use dom::window::Window;
+use js::jsapi::JSTracer;
+use msg::constellation_msg::PipelineId;
+use parse::Parser;
+use script_task::ScriptTask;
+use std::cell::Cell;
 use url::Url;
 use util::str::DOMString;
-use xml5ever::tree_builder::{NodeOrText, TreeSink};
+use xml5ever::tokenizer;
+use xml5ever::tree_builder::{self, NodeOrText, XmlTreeBuilder};
+
+pub type Tokenizer = tokenizer::XmlTokenizer<XmlTreeBuilder<JS<Node>, Sink>>;
 
 #[must_root]
 #[derive(JSTraceable, HeapSizeOf)]
@@ -36,9 +47,115 @@ impl Sink {
 #[dom_struct]
 pub struct ServoXMLParser {
     reflector_: Reflector,
+    #[ignore_heap_size_of = "Defined in xml5ever"]
+    tokenizer: DOMRefCell<Tokenizer>,
+    /// Input chunks received but not yet passed to the parser.
+    pending_input: DOMRefCell<Vec<String>>,
+    /// The document associated with this parser.
+    document: JS<Document>,
+    /// True if this parser should avoid passing any further data to the tokenizer.
+    suspended: Cell<bool>,
+    /// Whether to expect any further input from the associated network request.
+    last_chunk_received: Cell<bool>,
+    /// The pipeline associated with this parse, unavailable if this parse does not
+    /// correspond to a page load.
+    pipeline: Option<PipelineId>,
+}
+
+impl<'a> Parser for &'a ServoXMLParser {
+    fn parse_chunk(self, input: String) {
+        self.document.set_current_parser(Some(ParserRef::XML(self)));
+        self.pending_input.borrow_mut().push(input);
+        if !self.is_suspended() {
+            self.parse_sync();
+        }
+    }
+
+    fn finish(self) {
+        assert!(!self.suspended.get());
+        assert!(self.pending_input.borrow().is_empty());
+
+        self.tokenizer.borrow_mut().end();
+        debug!("finished parsing");
+
+        self.document.set_current_parser(None);
+
+        if let Some(pipeline) = self.pipeline {
+            ScriptTask::parsing_complete(pipeline);
+        }
+    }
 }
 
 impl ServoXMLParser {
     pub fn new() {
+    }
+
+    pub fn window(&self) -> &Window {
+        self.document.window()
+    }
+
+    pub fn resume(&self) {
+        panic!()
+    }
+
+    pub fn suspend(&self) {
+        panic!()
+    }
+
+    pub fn is_suspended(&self) -> bool {
+        panic!()
+    }
+
+    pub fn parse_sync(&self) {
+        panic!()
+    }
+
+    pub fn pending_input(&self) -> &DOMRefCell<Vec<String>> {
+        &self.pending_input
+    }
+
+    pub fn set_plaintext_state(&self) {
+        //self.tokenizer.borrow_mut().set_plaintext_state()
+    }
+
+    pub fn end_tokenizer(&self) {
+        self.tokenizer.borrow_mut().end()
+    }
+
+    pub fn document(&self) -> &Document {
+        &self.document
+    }
+
+    pub fn last_chunk_received(&self) -> &Cell<bool> {
+        &self.last_chunk_received
+    }
+
+    pub fn tokenizer(&self) -> &DOMRefCell<Tokenizer> {
+        &self.tokenizer
+    }
+}
+
+struct Tracer {
+    trc: *mut JSTracer,
+}
+
+impl tree_builder::Tracer for Tracer {
+    type Handle = JS<Node>;
+    #[allow(unrooted_must_root)]
+    fn trace_handle(&self, node: JS<Node>) {
+        node.trace(self.trc);
+    }
+}
+
+impl JSTraceable for Tokenizer {
+    fn trace(&self, trc: *mut JSTracer) {
+        let tracer = Tracer {
+            trc: trc,
+        };
+        let tracer = &tracer as &tree_builder::Tracer<Handle=JS<Node>>;
+
+        let tree_builder = self.sink();
+        tree_builder.trace_handles(tracer);
+        tree_builder.sink().trace(trc);
     }
 }

--- a/components/script/script_task.rs
+++ b/components/script/script_task.rs
@@ -27,7 +27,7 @@ use dom::bindings::conversions::{FromJSValConvertible, StringificationBehavior};
 use dom::bindings::global::GlobalRef;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::js::{JS, RootCollection, trace_roots};
-use dom::bindings::js::{Root, RootCollectionPtr, RootedReference};
+use dom::bindings::js::{RootCollectionPtr, RootedReference};
 use dom::bindings::refcounted::{LiveDOMReferences, Trusted, TrustedReference, trace_refcounted_objects};
 use dom::bindings::trace::{JSTraceable, RootedVec, trace_traceables};
 use dom::bindings::utils::{DOM_CALLBACKS, WRAP_CALLBACKS};
@@ -37,7 +37,7 @@ use dom::element::Element;
 use dom::event::{Event, EventBubbles, EventCancelable};
 use dom::htmlanchorelement::HTMLAnchorElement;
 use dom::node::{Node, NodeDamage, window_from_node};
-use dom::servohtmlparser::{ParserContext, ServoHTMLParser};
+use dom::servohtmlparser::{ParserContext, ParserRoot};
 use dom::uievent::UIEvent;
 use dom::window::{ReflowReason, ScriptHelpers, Window};
 use dom::worker::TrustedWorkerAddress;
@@ -598,7 +598,7 @@ pub unsafe extern "C" fn shadow_check_callback(_cx: *mut JSContext,
 
 impl ScriptTask {
     pub fn page_fetch_complete(id: PipelineId, subpage: Option<SubpageId>, metadata: Metadata)
-                               -> Option<Root<ServoHTMLParser>> {
+                               -> Option<ParserRoot> {
         SCRIPT_TASK_ROOT.with(|root| {
             let script_task = unsafe { &*root.borrow().unwrap() };
             script_task.handle_page_fetch_complete(id, subpage, metadata)
@@ -1451,7 +1451,7 @@ impl ScriptTask {
     /// We have received notification that the response associated with a load has completed.
     /// Kick off the document and frame tree creation process using the result.
     fn handle_page_fetch_complete(&self, id: PipelineId, subpage: Option<SubpageId>,
-                                  metadata: Metadata) -> Option<Root<ServoHTMLParser>> {
+                                  metadata: Metadata) -> Option<ParserRoot> {
         let idx = self.incomplete_loads.borrow().iter().position(|load| {
             load.pipeline_id == id && load.parent_info.map(|info| info.1) == subpage
         });
@@ -1538,7 +1538,7 @@ impl ScriptTask {
 
     /// The entry point to document loading. Defines bindings, sets up the window and document
     /// objects, parses HTML and CSS, and kicks off initial layout.
-    fn load(&self, metadata: Metadata, incomplete: InProgressLoad) -> Root<ServoHTMLParser> {
+    fn load(&self, metadata: Metadata, incomplete: InProgressLoad) -> ParserRoot {
         let final_url = metadata.final_url.clone();
         debug!("ScriptTask: loading {} on page {:?}", incomplete.url.serialize(), incomplete.pipeline_id);
 


### PR DESCRIPTION
…stener.

This gets a bunch of complicated busywork out of the way of making use of the new XML parser. I was originally going to describe the problem that I came across when reading the source (the `ParserContext` object that is created by `ScriptTask::start_page_load` always uses the HTML parser), but decided that it was not a realistic piece of work to ask of your group. I think this was the right choice, since it took me several hours of experimentation to get this compiling :)
